### PR TITLE
use memcached for sessions in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
 end
 
 group :production do
+	gem 'dalli'
 	gem 'newrelic_rpm'
 	gem 'newrelic_moped'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     connection_pool (2.1.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
+    dalli (2.7.2)
     database_cleaner (1.3.0)
     diff-lcs (1.2.5)
     factory_girl (4.5.0)
@@ -98,6 +99,7 @@ PLATFORMS
 
 DEPENDENCIES
   bson_ext
+  dalli
   database_cleaner
   factory_girl (~> 4.0)
   haml

--- a/rpaproxy.rb
+++ b/rpaproxy.rb
@@ -14,7 +14,7 @@ require './models/client.rb'
 
 if production?
 	require 'rack/session/dalli'
-	use Rack::Session::Dalli
+	use Rack::Session::Dalli, cache: Dalli::Client.new, expire_after: 2592000
 else
 	use Rack::Session::Pool, expire_after: 2592000
 end

--- a/rpaproxy.rb
+++ b/rpaproxy.rb
@@ -12,14 +12,19 @@ require './models/log.rb'
 require './models/stat.rb'
 require './models/client.rb'
 
-enable :sessions
+if production?
+	require 'rack/session/dalli'
+	use Rack::Session::Dalli
+else
+	use Rack::Session::Pool, expire_after: 2592000
+end
+
 use OmniAuth::Builder do
 	provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
 	provider :developer unless production?
 end
 
 set :haml, { format: :html5, escape_html: true }
-set :protection, except: :session_hijacking
 
 configure do
 	Mongoid.load!("config/mongoid.yml")


### PR DESCRIPTION
pumaを導入して複数アプリケーションが同時に動くようになった (#26) ので、セッション情報をMemcacheに格納するようにしました。